### PR TITLE
Add phone number copy functionality with tooltip feedback

### DIFF
--- a/src/components/ChannelDetails/index.tsx
+++ b/src/components/ChannelDetails/index.tsx
@@ -19,6 +19,7 @@ import { ReactComponent as EditIcon } from '../../assets/svg/editIcon.svg'
 import { IDetailsProps } from '../ChannelDetailsContainer'
 // Helpers
 import { userLastActiveDateFormat } from '../../helpers'
+import { copyToClipboard } from '../../helpers/clipboard'
 import { makeUsername } from '../../helpers/message'
 import { getShowOnlyContactUsers } from '../../helpers/contacts'
 import { hideUserPresence } from '../../helpers/userHelper'
@@ -158,7 +159,9 @@ const Details = ({
     [THEME_COLORS.TEXT_SECONDARY]: textSecondary,
     [THEME_COLORS.BORDER]: borderThemeColor,
     [THEME_COLORS.TEXT_FOOTNOTE]: textFootnote,
-    [THEME_COLORS.SURFACE_2]: surface2
+    [THEME_COLORS.SURFACE_2]: surface2,
+    [THEME_COLORS.TOOLTIP_BACKGROUND]: tooltipBackground,
+    [THEME_COLORS.TEXT_ON_PRIMARY]: textOnPrimary
   } = useColor()
 
   const dispatch = useDispatch()
@@ -183,6 +186,8 @@ const Details = ({
   const detailsRef = useRef<any>(null)
   const detailsHeaderRef = useRef<any>(null)
   const openTimeOut = useRef<any>(null)
+  const copiedPhoneTimerRef = useRef<any>(null)
+  const [copiedPhone, setCopiedPhone] = useState(false)
   // const tabsRef = useRef<any>(null)
   const isDirectChannel = activeChannel && activeChannel.type === DEFAULT_CHANNEL_TYPE.DIRECT
   const isSelfChannel =
@@ -248,12 +253,32 @@ const Details = ({
     }
   }, [])
 
+  useEffect(() => {
+    return () => {
+      if (copiedPhoneTimerRef.current) {
+        clearTimeout(copiedPhoneTimerRef.current)
+      }
+    }
+  }, [])
+
   const handleTabChange = () => {
     if (detailsRef.current && detailsHeaderRef.current) {
       detailsRef.current.scrollTo({
         top: actionsHeight + detailsHeaderRef.current.offsetHeight,
         behavior: 'smooth'
       })
+    }
+  }
+
+  const handleCopyPhoneNumber = async () => {
+    if (directChannelUser?.id) {
+      const value = `+${directChannelUser.id}`
+      await copyToClipboard(value)
+      setCopiedPhone(true)
+      if (copiedPhoneTimerRef.current) {
+        clearTimeout(copiedPhoneTimerRef.current)
+      }
+      copiedPhoneTimerRef.current = setTimeout(() => setCopiedPhone(false), 1200)
     }
   }
 
@@ -352,16 +377,25 @@ const Details = ({
 
               {isDirectChannel ? (
                 <SubTitle color={textSecondary} fontSize={channelMembersFontSize} lineHeight={channelMembersLineHeight}>
-                  {showPhoneNumber && directChannelUser?.id
-                    ? `+${directChannelUser?.id}`
-                    : hideUserPresence && directChannelUser && hideUserPresence(directChannelUser)
-                      ? ''
-                      : directChannelUser &&
-                        directChannelUser.presence &&
-                        (directChannelUser.presence.state === USER_PRESENCE_STATUS.ONLINE
-                          ? 'Online'
-                          : directChannelUser.presence.lastActiveAt &&
-                            userLastActiveDateFormat(directChannelUser.presence.lastActiveAt))}
+                  {showPhoneNumber && directChannelUser?.id ? (
+                    <PhoneNumberContainer onClick={handleCopyPhoneNumber} role='button' aria-label='Copy phone number'>
+                      {`+${directChannelUser.id}`}
+                      {copiedPhone && (
+                        <CopiedTooltip background={tooltipBackground} color={textOnPrimary}>
+                          Copied
+                        </CopiedTooltip>
+                      )}
+                    </PhoneNumberContainer>
+                  ) : hideUserPresence && directChannelUser && hideUserPresence(directChannelUser) ? (
+                    ''
+                  ) : (
+                    directChannelUser &&
+                    directChannelUser.presence &&
+                    (directChannelUser.presence.state === USER_PRESENCE_STATUS.ONLINE
+                      ? 'Online'
+                      : directChannelUser.presence.lastActiveAt &&
+                        userLastActiveDateFormat(directChannelUser.presence.lastActiveAt))
+                  )}
                 </SubTitle>
               ) : (
                 <SubTitle color={textSecondary} fontSize={channelMembersFontSize} lineHeight={channelMembersLineHeight}>
@@ -619,4 +653,28 @@ const EditButton = styled.span<{ topPosition?: string; rightPosition?: string }>
   margin-left: 6px;
   cursor: pointer;
   color: #b2b6be;
+`
+
+const PhoneNumberContainer = styled.span`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: text;
+`
+
+const CopiedTooltip = styled.span<{ background: string; color: string }>`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(100% + 6px);
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: ${(props) => props.background};
+  color: ${(props) => props.color};
+  font-size: 12px;
+  line-height: 14px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
 `

--- a/src/helpers/clipboard.ts
+++ b/src/helpers/clipboard.ts
@@ -1,0 +1,24 @@
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch (e) {}
+
+  try {
+    if (typeof document !== 'undefined') {
+      const textarea = document.createElement('textarea')
+      textarea.value = text
+      textarea.style.position = 'fixed'
+      textarea.style.left = '-9999px'
+      document.body.appendChild(textarea)
+      textarea.focus()
+      textarea.select()
+      const successful = document.execCommand('copy')
+      document.body.removeChild(textarea)
+      return successful
+    }
+  } catch (e) {}
+  return false
+}


### PR DESCRIPTION
- Implemented a new `copyToClipboard` helper function for copying text to the clipboard.
- Updated the ChannelDetails component to allow users to click on the phone number to copy it, displaying a tooltip when copied.
- Added necessary state management and cleanup for the copy action.
- Styled the phone number container and tooltip for better user experience.