### PR TITLE
update join message clarity

### DIFF
--- a/src/components/Channel/index.tsx
+++ b/src/components/Channel/index.tsx
@@ -179,7 +179,8 @@ const ChannelMessageText = ({
               : makeUsername(
                   lastMessage.user && contactsMap && contactsMap[lastMessage.user.id],
                   lastMessage.user,
-                  getFromContacts
+                  getFromContacts,
+                  true
                 ))
           } ${
             lastMessage.body === 'CC'
@@ -229,7 +230,7 @@ const ChannelMessageText = ({
                     : lastMessage.body === 'LG'
                       ? 'Left this group'
                       : lastMessage.body === 'JL'
-                        ? 'Joined this group via invite link'
+                        ? 'Joined via invite link'
                         : ''
           }`
         ) : (


### PR DESCRIPTION
Update ChannelMessageText to improve user join message clarity

- Modified the join message text to be more concise by changing 'Joined this group via invite link' to 'Joined via invite link'.
- Added a new parameter to the makeUsername function call for better handling of user data.