### PR TITLE
message seen status updated real time

### DIFF
--- a/src/store/message/saga.ts
+++ b/src/store/message/saga.ts
@@ -466,7 +466,8 @@ function* sendMessage(action: IAction): any {
               metadata: messageResponse.metadata,
               parentMessage: messageResponse.parentMessage,
               repliedInThread: messageResponse.repliedInThread,
-              createdAt: messageResponse.createdAt
+              createdAt: messageResponse.createdAt,
+              channelId: channel.id
             }
             yield put(updateMessageAC(messageToSend.tid as string, JSON.parse(JSON.stringify(messageUpdateData))))
             updateMessageOnMap(channel.id, {


### PR DESCRIPTION
Add channelId to message update data in sendMessage saga
- Enhanced the sendMessage function to include channelId in the message update data.
- This change ensures that the channel context is preserved when updating messages.