### PR TITLE
grouping by months in the detailstab sections

### DIFF
--- a/src/components/ChannelDetails/DetailsTab/Files/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Files/index.tsx
@@ -18,6 +18,7 @@ import { channelDetailsTabs } from '../../../../helpers/constants'
 import { AttachmentPreviewTitle } from '../../../../UIHelper'
 import { THEME_COLORS } from '../../../../UIHelper/constants'
 import { useColor } from '../../../../hooks'
+import MonthHeader from '../MonthHeader'
 
 interface IProps {
   channelId: string
@@ -98,28 +99,9 @@ const Files = ({
             }
           }
 
-          let monthComponent: React.ReactNode = null
-
-          if (index === 0) {
-            monthComponent = (
-              <MonthHeader color={textSecondary}>
-                {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-              </MonthHeader>
-            )
-          } else if (
-            index > 0 &&
-            new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
-          ) {
-            monthComponent = (
-              <MonthHeader color={textSecondary}>
-                {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-              </MonthHeader>
-            )
-          }
-
           return (
             <React.Fragment key={file.id}>
-              {monthComponent}
+              <MonthHeader file={file} index={index} attachments={attachments} padding='11px 16px' />
               <FileItem
                 // onMouseEnter={(e: any) => e.currentTarget.classList.add('isHover')}
                 // onMouseLeave={(e: any) => e.currentTarget.classList.remove('isHover')}
@@ -316,13 +298,4 @@ const FileSizeAndDate = styled.span<{ fontSize?: string; lineHeight?: string; co
   line-height: ${(props) => props.lineHeight || '16px'};
   color: ${(props) => props.color};
   margin-top: 2px;
-`
-const MonthHeader = styled.div<{ color: string }>`
-  padding: 11px 16px;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 13px;
-  line-height: 16px;
-  color: ${(props) => props.color};
-  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Files/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Files/index.tsx
@@ -101,7 +101,12 @@ const Files = ({
 
           return (
             <React.Fragment key={file.id}>
-              <MonthHeader file={file} index={index} attachments={attachments} padding='11px 16px' />
+              <MonthHeader
+                currentCreatedAt={file.createdAt}
+                previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
+                isFirst={index === 0}
+                padding='12px 14px'
+              />
               <FileItem
                 // onMouseEnter={(e: any) => e.currentTarget.classList.add('isHover')}
                 // onMouseLeave={(e: any) => e.currentTarget.classList.remove('isHover')}

--- a/src/components/ChannelDetails/DetailsTab/Files/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Files/index.tsx
@@ -84,7 +84,7 @@ const Files = ({
   return (
     <Container>
       {attachments.map(
-        (file: IAttachment) => {
+        (file: IAttachment, index: number) => {
           const metas = file.metadata && isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata
           let withPrefix = true
           let attachmentThumb = ''
@@ -97,77 +97,102 @@ const Files = ({
               attachmentThumb = metas.tmb
             }
           }
+
+          let monthComponent: React.ReactNode = null
+
+          if (index === 0) {
+            monthComponent = (
+              <MonthHeader color={textSecondary}>
+                {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+              </MonthHeader>
+            )
+          } else if (
+            index > 0 &&
+            new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
+          ) {
+            monthComponent = (
+              <MonthHeader color={textSecondary}>
+                {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+              </MonthHeader>
+            )
+          }
+
           return (
-            <FileItem
-              key={file.id}
-              // onMouseEnter={(e: any) => e.currentTarget.classList.add('isHover')}
-              // onMouseLeave={(e: any) => e.currentTarget.classList.remove('isHover')}
-              hoverBackgroundColor={filePreviewHoverBackgroundColor || backgroundHovered}
-            >
-              {metas && metas.tmb ? (
-                <FileThumb draggable={false} src={`${withPrefix ? 'data:image/jpeg;base64,' : ''}${attachmentThumb}`} />
-              ) : (
-                <React.Fragment>
-                  <FileIconCont iconColor={accentColor} fillColor={surface1}>
-                    {filePreviewIcon || <FileIcon />}
-                  </FileIconCont>
-                  <FileHoverIconCont iconColor={accentColor} fillColor={surface1}>
-                    {filePreviewHoverIcon || <FileIcon />}
-                  </FileHoverIconCont>
-                </React.Fragment>
-              )}
-              <div>
-                <AttachmentPreviewTitle
-                  fontSize={fileNameFontSize}
-                  lineHeight={fileNameLineHeight}
-                  color={filePreviewTitleColor || textPrimary}
-                >
-                  {formatLargeText(file.name, nameMaxLength)}
-                </AttachmentPreviewTitle>
-                <FileSizeAndDate
-                  fontSize={fileSizeFontSize}
-                  lineHeight={fileSizeLineHeight}
-                  color={filePreviewSizeColor || textSecondary}
-                >
-                  {file.size
-                    ? `${bytesToSize(file.size)} • ${formatChannelDetailsDate(file.createdAt)}`
-                    : formatChannelDetailsDate(file.createdAt)}
-                </FileSizeAndDate>
-              </div>
-              <DownloadWrapper
-                visible={!!downloadingFilesMap[file.id!]}
-                iconColor={accentColor}
-                onClick={() => handleDownloadFile(file)}
+            <React.Fragment key={file.id}>
+              {monthComponent}
+              <FileItem
+                // onMouseEnter={(e: any) => e.currentTarget.classList.add('isHover')}
+                // onMouseLeave={(e: any) => e.currentTarget.classList.remove('isHover')}
+                hoverBackgroundColor={filePreviewHoverBackgroundColor || backgroundHovered}
               >
-                {downloadingFilesMap[file.id!] ? (
-                  <ProgressWrapper>
-                    <CircularProgressbar
-                      minValue={0}
-                      maxValue={100}
-                      value={downloadingFilesMap[file.id!].uploadPercent || 0}
-                      backgroundPadding={6}
-                      background={true}
-                      text=''
-                      styles={{
-                        background: {
-                          fill: `${overlayBackground2}66`
-                        },
-                        path: {
-                          stroke: accentColor,
-                          strokeLinecap: 'butt',
-                          strokeWidth: '6px',
-                          transition: 'stroke-dashoffset 0.5s ease 0s',
-                          transform: 'rotate(0turn)',
-                          transformOrigin: 'center center'
-                        }
-                      }}
-                    />
-                  </ProgressWrapper>
+                {metas && metas.tmb ? (
+                  <FileThumb
+                    draggable={false}
+                    src={`${withPrefix ? 'data:image/jpeg;base64,' : ''}${attachmentThumb}`}
+                  />
                 ) : (
-                  filePreviewDownloadIcon || <Download />
+                  <React.Fragment>
+                    <FileIconCont iconColor={accentColor} fillColor={surface1}>
+                      {filePreviewIcon || <FileIcon />}
+                    </FileIconCont>
+                    <FileHoverIconCont iconColor={accentColor} fillColor={surface1}>
+                      {filePreviewHoverIcon || <FileIcon />}
+                    </FileHoverIconCont>
+                  </React.Fragment>
                 )}
-              </DownloadWrapper>
-            </FileItem>
+                <div>
+                  <AttachmentPreviewTitle
+                    fontSize={fileNameFontSize}
+                    lineHeight={fileNameLineHeight}
+                    color={filePreviewTitleColor || textPrimary}
+                  >
+                    {formatLargeText(file.name, nameMaxLength)}
+                  </AttachmentPreviewTitle>
+                  <FileSizeAndDate
+                    fontSize={fileSizeFontSize}
+                    lineHeight={fileSizeLineHeight}
+                    color={filePreviewSizeColor || textSecondary}
+                  >
+                    {file.size
+                      ? `${bytesToSize(file.size)} • ${formatChannelDetailsDate(file.createdAt)}`
+                      : formatChannelDetailsDate(file.createdAt)}
+                  </FileSizeAndDate>
+                </div>
+                <DownloadWrapper
+                  visible={!!downloadingFilesMap[file.id!]}
+                  iconColor={accentColor}
+                  onClick={() => handleDownloadFile(file)}
+                >
+                  {downloadingFilesMap[file.id!] ? (
+                    <ProgressWrapper>
+                      <CircularProgressbar
+                        minValue={0}
+                        maxValue={100}
+                        value={downloadingFilesMap[file.id!].uploadPercent || 0}
+                        backgroundPadding={6}
+                        background={true}
+                        text=''
+                        styles={{
+                          background: {
+                            fill: `${overlayBackground2}66`
+                          },
+                          path: {
+                            stroke: accentColor,
+                            strokeLinecap: 'butt',
+                            strokeWidth: '6px',
+                            transition: 'stroke-dashoffset 0.5s ease 0s',
+                            transform: 'rotate(0turn)',
+                            transformOrigin: 'center center'
+                          }
+                        }}
+                      />
+                    </ProgressWrapper>
+                  ) : (
+                    filePreviewDownloadIcon || <Download />
+                  )}
+                </DownloadWrapper>
+              </FileItem>
+            </React.Fragment>
           )
         }
         // <FileItemWrapper >
@@ -291,4 +316,13 @@ const FileSizeAndDate = styled.span<{ fontSize?: string; lineHeight?: string; co
   line-height: ${(props) => props.lineHeight || '16px'};
   color: ${(props) => props.color};
   margin-top: 2px;
+`
+const MonthHeader = styled.div<{ color: string }>`
+  padding: 11px 16px;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 16px;
+  color: ${(props) => props.color};
+  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Files/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Files/index.tsx
@@ -105,7 +105,7 @@ const Files = ({
                 currentCreatedAt={file.createdAt}
                 previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
                 isFirst={index === 0}
-                padding='12px 14px'
+                padding='14px 14px 0'
               />
               <FileItem
                 // onMouseEnter={(e: any) => e.currentTarget.classList.add('isHover')}

--- a/src/components/ChannelDetails/DetailsTab/Links/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Links/index.tsx
@@ -44,7 +44,7 @@ const Links = ({
               currentCreatedAt={file.createdAt}
               previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
               isFirst={index === 0}
-              padding='9px 16px'
+              padding='9px 14px'
             />
             <LinkItem
               link={file.url}

--- a/src/components/ChannelDetails/DetailsTab/Links/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Links/index.tsx
@@ -8,6 +8,8 @@ import { activeTabAttachmentsSelector } from '../../../../store/message/selector
 // Helpers
 import { IAttachment } from '../../../../types'
 import { channelDetailsTabs } from '../../../../helpers/constants'
+import { THEME_COLORS } from '../../../../UIHelper/constants'
+import { useColor } from '../../../../hooks'
 // Components
 import LinkItem from './linkItem'
 
@@ -30,23 +32,47 @@ const Links = ({
 }: IProps) => {
   const dispatch = useDispatch()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
+  const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
 
   useEffect(() => {
     dispatch(getAttachmentsAC(channelId, channelDetailsTabs.link))
   }, [channelId])
   return (
     <Container>
-      {attachments.map((file: IAttachment) => (
-        <LinkItem
-          key={file.id}
-          link={file.url}
-          linkPreviewColor={linkPreviewColor}
-          linkPreviewHoverBackgroundColor={linkPreviewHoverBackgroundColor}
-          linkPreviewHoverIcon={linkPreviewHoverIcon}
-          linkPreviewTitleColor={linkPreviewTitleColor}
-          linkPreviewIcon={linkPreviewIcon}
-        />
-      ))}
+      {attachments.map((file: IAttachment, index: number) => {
+        let monthComponent: React.ReactNode = null
+
+        if (index === 0) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        } else if (
+          index > 0 &&
+          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
+        ) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        }
+
+        return (
+          <React.Fragment key={file.id}>
+            {monthComponent}
+            <LinkItem
+              link={file.url}
+              linkPreviewColor={linkPreviewColor}
+              linkPreviewHoverBackgroundColor={linkPreviewHoverBackgroundColor}
+              linkPreviewHoverIcon={linkPreviewHoverIcon}
+              linkPreviewTitleColor={linkPreviewTitleColor}
+              linkPreviewIcon={linkPreviewIcon}
+            />
+          </React.Fragment>
+        )
+      })}
     </Container>
   )
 }
@@ -60,4 +86,13 @@ const Container = styled.ul`
   overflow-y: auto;
   list-style: none;
   transition: all 0.2s;
+`
+const MonthHeader = styled.div<{ color: string }>`
+  padding: 9px 16px;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 16px;
+  color: ${(props) => props.color};
+  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Links/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Links/index.tsx
@@ -8,10 +8,9 @@ import { activeTabAttachmentsSelector } from '../../../../store/message/selector
 // Helpers
 import { IAttachment } from '../../../../types'
 import { channelDetailsTabs } from '../../../../helpers/constants'
-import { THEME_COLORS } from '../../../../UIHelper/constants'
-import { useColor } from '../../../../hooks'
 // Components
 import LinkItem from './linkItem'
+import MonthHeader from '../MonthHeader'
 
 interface IProps {
   channelId: string
@@ -32,7 +31,6 @@ const Links = ({
 }: IProps) => {
   const dispatch = useDispatch()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
-  const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
 
   useEffect(() => {
     dispatch(getAttachmentsAC(channelId, channelDetailsTabs.link))
@@ -40,28 +38,9 @@ const Links = ({
   return (
     <Container>
       {attachments.map((file: IAttachment, index: number) => {
-        let monthComponent: React.ReactNode = null
-
-        if (index === 0) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        } else if (
-          index > 0 &&
-          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
-        ) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        }
-
         return (
           <React.Fragment key={file.id}>
-            {monthComponent}
+            <MonthHeader file={file} index={index} attachments={attachments} padding='9px 16px' />
             <LinkItem
               link={file.url}
               linkPreviewColor={linkPreviewColor}
@@ -86,13 +65,4 @@ const Container = styled.ul`
   overflow-y: auto;
   list-style: none;
   transition: all 0.2s;
-`
-const MonthHeader = styled.div<{ color: string }>`
-  padding: 9px 16px;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 13px;
-  line-height: 16px;
-  color: ${(props) => props.color};
-  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Links/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Links/index.tsx
@@ -40,7 +40,12 @@ const Links = ({
       {attachments.map((file: IAttachment, index: number) => {
         return (
           <React.Fragment key={file.id}>
-            <MonthHeader file={file} index={index} attachments={attachments} padding='9px 16px' />
+            <MonthHeader
+              currentCreatedAt={file.createdAt}
+              previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
+              isFirst={index === 0}
+              padding='9px 16px'
+            />
             <LinkItem
               link={file.url}
               linkPreviewColor={linkPreviewColor}

--- a/src/components/ChannelDetails/DetailsTab/Links/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Links/index.tsx
@@ -44,7 +44,7 @@ const Links = ({
               currentCreatedAt={file.createdAt}
               previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
               isFirst={index === 0}
-              padding='9px 14px'
+              padding='6px 14px 0'
             />
             <LinkItem
               link={file.url}

--- a/src/components/ChannelDetails/DetailsTab/Media/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Media/index.tsx
@@ -20,7 +20,7 @@ interface IProps {
 }
 
 const Media = ({ channel }: IProps) => {
-  const { [THEME_COLORS.BACKGROUND]: background } = useColor()
+  const { [THEME_COLORS.BACKGROUND]: background, [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
   const [mediaFile, setMediaFile] = useState<any>(null)
   const dispatch = useDispatch()
@@ -33,35 +33,59 @@ const Media = ({ channel }: IProps) => {
   }, [channel.id])
   return (
     <Container>
-      {attachments.map((file: IAttachment) => (
-        <MediaItem key={file.id}>
-          {file.type === 'image' ? (
-            <Attachment
-              attachment={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
-              handleMediaItemClick={handleMediaItemClick}
-              backgroundColor={background}
-              borderRadius='8px'
-              isDetailsView
-            />
-          ) : (
-            // <img src={file.url} alt='' />
+      {attachments.map((file: IAttachment, index: number) => {
+        let monthComponent: React.ReactNode = null
 
-            <Attachment
-              attachment={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
-              handleMediaItemClick={handleMediaItemClick}
-              backgroundColor={background}
-              borderRadius='8px'
-              isDetailsView
-            />
-            /* <video>
-              <source src={file.url} type={`video/${getFileExtension(file.name)}`} />
-              <source src={file.url} type='video/ogg' />
-              <track default kind='captions' srcLang='en' src='/media/examples/friday.vtt' />
-              Your browser does not support the video tag.
-            </video> */
-          )}
-        </MediaItem>
-      ))}
+        if (index === 0) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        } else if (
+          index > 0 &&
+          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
+        ) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        }
+
+        return (
+          <React.Fragment key={file.id}>
+            {monthComponent}
+            <MediaItem>
+              {file.type === 'image' ? (
+                <Attachment
+                  attachment={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
+                  handleMediaItemClick={handleMediaItemClick}
+                  backgroundColor={background}
+                  borderRadius='8px'
+                  isDetailsView
+                />
+              ) : (
+                // <img src={file.url} alt='' />
+
+                <Attachment
+                  attachment={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
+                  handleMediaItemClick={handleMediaItemClick}
+                  backgroundColor={background}
+                  borderRadius='8px'
+                  isDetailsView
+                />
+                /* <video>
+                  <source src={file.url} type={`video/${getFileExtension(file.name)}`} />
+                  <source src={file.url} type='video/ogg' />
+                  <track default kind='captions' srcLang='en' src='/media/examples/friday.vtt' />
+                  Your browser does not support the video tag.
+                </video> */
+              )}
+            </MediaItem>
+          </React.Fragment>
+        )
+      })}
       {mediaFile && (
         <SliderPopup
           channel={channel}
@@ -95,4 +119,14 @@ const MediaItem = styled.div`
   border-radius: 8px;
   overflow: hidden;
   margin: 2px;
+`
+const MonthHeader = styled.div<{ color: string }>`
+  width: 100%;
+  padding: 11px 6px;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 16px;
+  color: ${(props) => props.color};
+  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Media/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Media/index.tsx
@@ -14,13 +14,14 @@ import Attachment from '../../../Attachment'
 import SliderPopup from '../../../../common/popups/sliderPopup'
 import { useColor } from '../../../../hooks'
 import { THEME_COLORS } from '../../../../UIHelper/constants'
+import MonthHeader from '../MonthHeader'
 
 interface IProps {
   channel: IChannel
 }
 
 const Media = ({ channel }: IProps) => {
-  const { [THEME_COLORS.BACKGROUND]: background, [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
+  const { [THEME_COLORS.BACKGROUND]: background } = useColor()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
   const [mediaFile, setMediaFile] = useState<any>(null)
   const dispatch = useDispatch()
@@ -34,28 +35,9 @@ const Media = ({ channel }: IProps) => {
   return (
     <Container>
       {attachments.map((file: IAttachment, index: number) => {
-        let monthComponent: React.ReactNode = null
-
-        if (index === 0) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        } else if (
-          index > 0 &&
-          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
-        ) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        }
-
         return (
           <React.Fragment key={file.id}>
-            {monthComponent}
+            <MonthHeader file={file} index={index} attachments={attachments} padding='11px 6px' fullWidth />
             <MediaItem>
               {file.type === 'image' ? (
                 <Attachment
@@ -119,14 +101,4 @@ const MediaItem = styled.div`
   border-radius: 8px;
   overflow: hidden;
   margin: 2px;
-`
-const MonthHeader = styled.div<{ color: string }>`
-  width: 100%;
-  padding: 11px 6px;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 13px;
-  line-height: 16px;
-  color: ${(props) => props.color};
-  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Media/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Media/index.tsx
@@ -41,7 +41,7 @@ const Media = ({ channel }: IProps) => {
               currentCreatedAt={file.createdAt}
               previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
               isFirst={index === 0}
-              padding='11px 6px'
+              padding='9px 6px'
               fullWidth
             />
             <MediaItem>

--- a/src/components/ChannelDetails/DetailsTab/Media/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Media/index.tsx
@@ -37,7 +37,13 @@ const Media = ({ channel }: IProps) => {
       {attachments.map((file: IAttachment, index: number) => {
         return (
           <React.Fragment key={file.id}>
-            <MonthHeader file={file} index={index} attachments={attachments} padding='11px 6px' fullWidth />
+            <MonthHeader
+              currentCreatedAt={file.createdAt}
+              previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
+              isFirst={index === 0}
+              padding='11px 6px'
+              fullWidth
+            />
             <MediaItem>
               {file.type === 'image' ? (
                 <Attachment

--- a/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
+++ b/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
@@ -1,40 +1,35 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
-import { IAttachment } from '../../../types'
 import { THEME_COLORS } from '../../../UIHelper/constants'
 import { useColor } from '../../../hooks'
 
 interface IProps {
-  file: IAttachment
-  index: number
-  attachments: IAttachment[]
+  currentCreatedAt: string | number | Date
+  previousCreatedAt?: string | number | Date
+  isFirst: boolean
   padding?: string
   fullWidth?: boolean
 }
 
-const MonthHeader = ({ file, index, attachments, padding, fullWidth }: IProps) => {
+const MonthHeader = ({ currentCreatedAt, previousCreatedAt, isFirst, padding, fullWidth }: IProps) => {
   const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
 
-  let monthComponent: React.ReactNode = null
+  const monthComponent = useMemo(() => {
+    const shouldShowHeader =
+      isFirst || (previousCreatedAt && new Date(currentCreatedAt).getMonth() !== new Date(previousCreatedAt).getMonth())
 
-  if (index === 0) {
-    monthComponent = (
+    if (!shouldShowHeader) {
+      return null
+    }
+
+    return (
       <MonthHeaderContainer color={textSecondary} padding={padding} fullWidth={fullWidth}>
-        {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+        {new Date(currentCreatedAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
       </MonthHeaderContainer>
     )
-  } else if (
-    index > 0 &&
-    new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
-  ) {
-    monthComponent = (
-      <MonthHeaderContainer color={textSecondary} padding={padding} fullWidth={fullWidth}>
-        {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-      </MonthHeaderContainer>
-    )
-  }
+  }, [currentCreatedAt, previousCreatedAt, isFirst, textSecondary, padding, fullWidth])
 
-  return <>{monthComponent}</>
+  return monthComponent
 }
 
 export default MonthHeader

--- a/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
+++ b/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
@@ -35,7 +35,7 @@ const MonthHeader = ({ currentCreatedAt, previousCreatedAt, isFirst, padding, fu
 export default MonthHeader
 
 const MonthHeaderContainer = styled.div<{ color: string; padding?: string; fullWidth?: boolean }>`
-  padding: ${(props) => props.padding || '11px 16px'};
+  padding: ${(props) => props.padding || '9px 12px'};
   width: ${(props) => (props.fullWidth ? '100%' : 'auto')};
   font-style: normal;
   font-weight: 500;

--- a/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
+++ b/src/components/ChannelDetails/DetailsTab/MonthHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import styled from 'styled-components'
+import { IAttachment } from '../../../types'
+import { THEME_COLORS } from '../../../UIHelper/constants'
+import { useColor } from '../../../hooks'
+
+interface IProps {
+  file: IAttachment
+  index: number
+  attachments: IAttachment[]
+  padding?: string
+  fullWidth?: boolean
+}
+
+const MonthHeader = ({ file, index, attachments, padding, fullWidth }: IProps) => {
+  const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
+
+  let monthComponent: React.ReactNode = null
+
+  if (index === 0) {
+    monthComponent = (
+      <MonthHeaderContainer color={textSecondary} padding={padding} fullWidth={fullWidth}>
+        {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+      </MonthHeaderContainer>
+    )
+  } else if (
+    index > 0 &&
+    new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
+  ) {
+    monthComponent = (
+      <MonthHeaderContainer color={textSecondary} padding={padding} fullWidth={fullWidth}>
+        {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+      </MonthHeaderContainer>
+    )
+  }
+
+  return <>{monthComponent}</>
+}
+
+export default MonthHeader
+
+const MonthHeaderContainer = styled.div<{ color: string; padding?: string; fullWidth?: boolean }>`
+  padding: ${(props) => props.padding || '11px 16px'};
+  width: ${(props) => (props.fullWidth ? '100%' : 'auto')};
+  font-style: normal;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 16px;
+  color: ${(props) => props.color};
+  text-transform: uppercase;
+`

--- a/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
@@ -43,7 +43,12 @@ const Voices = ({
       {attachments.map((file: IAttachment, index: number) => {
         return (
           <React.Fragment key={file.id}>
-            <MonthHeader file={file} index={index} attachments={attachments} padding='9px 16px' />
+            <MonthHeader
+              currentCreatedAt={file.createdAt}
+              previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
+              isFirst={index === 0}
+              padding='9px 16px'
+            />
             <VoiceItem
               file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
               voicePreviewDateAndTimeColor={voicePreviewDateAndTimeColor}

--- a/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
@@ -8,8 +8,7 @@ import { IAttachment } from '../../../../types'
 import { getAttachmentsAC } from '../../../../store/message/actions'
 import VoiceItem from './voiceItem'
 import { isJSON } from '../../../../helpers/message'
-import { THEME_COLORS } from '../../../../UIHelper/constants'
-import { useColor } from '../../../../hooks'
+import MonthHeader from '../MonthHeader'
 
 interface IProps {
   channelId: string
@@ -34,7 +33,6 @@ const Voices = ({
 }: IProps) => {
   const dispatch = useDispatch()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
-  const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
 
   useEffect(() => {
     dispatch(getAttachmentsAC(channelId, channelDetailsTabs.voice))
@@ -43,28 +41,9 @@ const Voices = ({
   return (
     <Container>
       {attachments.map((file: IAttachment, index: number) => {
-        let monthComponent: React.ReactNode = null
-
-        if (index === 0) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        } else if (
-          index > 0 &&
-          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
-        ) {
-          monthComponent = (
-            <MonthHeader color={textSecondary}>
-              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
-            </MonthHeader>
-          )
-        }
-
         return (
           <React.Fragment key={file.id}>
-            {monthComponent}
+            <MonthHeader file={file} index={index} attachments={attachments} padding='9px 16px' />
             <VoiceItem
               file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
               voicePreviewDateAndTimeColor={voicePreviewDateAndTimeColor}
@@ -91,13 +70,4 @@ const Container = styled.ul`
   overflow-y: auto;
   list-style: none;
   transition: all 0.2s;
-`
-const MonthHeader = styled.div<{ color: string }>`
-  padding: 9px 16px;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 13px;
-  line-height: 16px;
-  color: ${(props) => props.color};
-  text-transform: uppercase;
 `

--- a/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
@@ -47,7 +47,7 @@ const Voices = ({
               currentCreatedAt={file.createdAt}
               previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
               isFirst={index === 0}
-              padding='7px 14px'
+              padding='7px 14px 2px'
             />
             <VoiceItem
               file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}

--- a/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
@@ -47,7 +47,7 @@ const Voices = ({
               currentCreatedAt={file.createdAt}
               previousCreatedAt={index > 0 ? attachments[index - 1].createdAt : undefined}
               isFirst={index === 0}
-              padding='9px 16px'
+              padding='7px 14px'
             />
             <VoiceItem
               file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}

--- a/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
+++ b/src/components/ChannelDetails/DetailsTab/Voices/index.tsx
@@ -8,6 +8,8 @@ import { IAttachment } from '../../../../types'
 import { getAttachmentsAC } from '../../../../store/message/actions'
 import VoiceItem from './voiceItem'
 import { isJSON } from '../../../../helpers/message'
+import { THEME_COLORS } from '../../../../UIHelper/constants'
+import { useColor } from '../../../../hooks'
 
 interface IProps {
   channelId: string
@@ -32,6 +34,7 @@ const Voices = ({
 }: IProps) => {
   const dispatch = useDispatch()
   const attachments = useSelector(activeTabAttachmentsSelector, shallowEqual) || []
+  const { [THEME_COLORS.TEXT_SECONDARY]: textSecondary } = useColor()
 
   useEffect(() => {
     dispatch(getAttachmentsAC(channelId, channelDetailsTabs.voice))
@@ -39,19 +42,42 @@ const Voices = ({
 
   return (
     <Container>
-      {attachments.map((file: IAttachment) => (
-        <VoiceItem
-          key={file.id}
-          file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
-          voicePreviewDateAndTimeColor={voicePreviewDateAndTimeColor}
-          voicePreviewHoverBackgroundColor={voicePreviewHoverBackgroundColor}
-          voicePreviewPlayHoverIcon={voicePreviewPlayIcon}
-          voicePreviewPlayIcon={voicePreviewPlayHoverIcon}
-          voicePreviewPauseIcon={voicePreviewPauseIcon}
-          voicePreviewPauseHoverIcon={voicePreviewPauseHoverIcon}
-          voicePreviewTitleColor={voicePreviewTitleColor}
-        />
-      ))}
+      {attachments.map((file: IAttachment, index: number) => {
+        let monthComponent: React.ReactNode = null
+
+        if (index === 0) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        } else if (
+          index > 0 &&
+          new Date(file.createdAt).getMonth() !== new Date(attachments[index - 1].createdAt).getMonth()
+        ) {
+          monthComponent = (
+            <MonthHeader color={textSecondary}>
+              {new Date(file.createdAt).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+            </MonthHeader>
+          )
+        }
+
+        return (
+          <React.Fragment key={file.id}>
+            {monthComponent}
+            <VoiceItem
+              file={{ ...file, metadata: isJSON(file.metadata) ? JSON.parse(file.metadata) : file.metadata }}
+              voicePreviewDateAndTimeColor={voicePreviewDateAndTimeColor}
+              voicePreviewHoverBackgroundColor={voicePreviewHoverBackgroundColor}
+              voicePreviewPlayHoverIcon={voicePreviewPlayIcon}
+              voicePreviewPlayIcon={voicePreviewPlayHoverIcon}
+              voicePreviewPauseIcon={voicePreviewPauseIcon}
+              voicePreviewPauseHoverIcon={voicePreviewPauseHoverIcon}
+              voicePreviewTitleColor={voicePreviewTitleColor}
+            />
+          </React.Fragment>
+        )
+      })}
     </Container>
   )
 }
@@ -65,4 +91,13 @@ const Container = styled.ul`
   overflow-y: auto;
   list-style: none;
   transition: all 0.2s;
+`
+const MonthHeader = styled.div<{ color: string }>`
+  padding: 9px 16px;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 16px;
+  color: ${(props) => props.color};
+  text-transform: uppercase;
 `


### PR DESCRIPTION
Enhance file, link, media, and voice components with month headers
- Added month headers to Files, Links, Media, and Voices components to group attachments by creation month, improving organization and readability.
- Updated the rendering logic to conditionally display month headers based on the creation date of attachments.
- Introduced a styled MonthHeader component for consistent styling across all sections.