### PR TITLE
Modify OGMetadata when the description is a symbol

### DIFF
--- a/src/components/Message/OGMetadata/index.tsx
+++ b/src/components/Message/OGMetadata/index.tsx
@@ -20,6 +20,11 @@ const validateUrl = (url: string) => {
   }
 }
 
+const isDescriptionOnlySymbol = (description: string | undefined): boolean => {
+  const trimmed = description?.trim()
+  return !!trimmed && !/[a-zA-Z0-9]/.test(trimmed)
+}
+
 const OGMetadata = ({
   attachments,
   state,
@@ -242,7 +247,7 @@ const OGMetadata = ({
         {
           key: 'title',
           order: resolvedOrder?.title ?? 2,
-          render: ogShowTitle && metadata?.og?.title && (
+          render: ogShowTitle && metadata?.og?.title && !isDescriptionOnlySymbol(metadata?.og?.description) && (
             <Title maxWidth={maxWidth} shouldAnimate={shouldAnimate} padding={infoPadding} color={textPrimary}>
               <span>{metadata?.og?.title?.trim()}</span>
             </Title>
@@ -251,11 +256,13 @@ const OGMetadata = ({
         {
           key: 'description',
           order: resolvedOrder?.description ?? 3,
-          render: ogShowDescription && metadata?.og?.description && (
-            <Desc maxWidth={maxWidth} shouldAnimate={shouldAnimate} color={textSecondary} padding={infoPadding}>
-              {metadata?.og?.description?.trim()}
-            </Desc>
-          )
+          render: ogShowDescription &&
+            metadata?.og?.description &&
+            !isDescriptionOnlySymbol(metadata?.og?.description) && (
+              <Desc maxWidth={maxWidth} shouldAnimate={shouldAnimate} color={textSecondary} padding={infoPadding}>
+                {metadata?.og?.description?.trim()}
+              </Desc>
+            )
         },
         {
           key: 'link',
@@ -466,8 +473,7 @@ const OGText = styled.div<{ shouldAnimate: boolean; margin: boolean }>`
 
 const Title = styled.p<{ maxWidth: number; shouldAnimate: boolean; padding?: string; color: string }>`
   ${sharedKeyframes}
-  // font-family: Inter;
-  font-weight: 500;
+  font-weight: bold;
   font-size: 14px;
   line-height: 18px;
   letter-spacing: 0px;


### PR DESCRIPTION
Enhance OGMetadata component to exclude invalid descriptions
- Introduced a utility function `isDescriptionOnlySymbol` to filter out descriptions that contain only whitespace or symbols.
- Updated the rendering logic for the description to ensure only valid descriptions are displayed, improving metadata clarity.
- Changed the font weight of the Title styled component to bold for better emphasis.