### PR TITLE
Message bubble size adjustment 

### DIFF
--- a/src/components/Message/MessageBody/index.tsx
+++ b/src/components/Message/MessageBody/index.tsx
@@ -28,7 +28,7 @@ import { IMessageActions, IMessageStyles } from '../Message.types'
 import MessageStatusAndTime from '../MessageStatusAndTime'
 import PollMessage from '../PollMessage'
 import log from 'loglevel'
-import { OGMetadata } from '../OGMetadata'
+import { isDescriptionOnlySymbol, OGMetadata } from '../OGMetadata'
 import { MESSAGE_TYPE } from 'types/enum'
 
 interface IMessageBodyProps {
@@ -445,7 +445,7 @@ const MessageBody = ({
   }, [oGMetadata, linkAttachment?.url])
 
   const ogMetadataContainerWidth = useMemo(() => {
-    if (!linkMetadata || !linkAttachment) return ogMetadataProps?.maxWidth || 400
+    if (!linkMetadata || !linkAttachment) return undefined
 
     if (hasLongLinkAttachmentUrl) {
       return 400
@@ -457,9 +457,13 @@ const MessageBody = ({
     const calculatedImageHeight =
       imageWidth && imageHeight ? imageHeight / (imageWidth / (ogMetadataProps?.maxWidth || 400)) : 0
     const showImage = hasImage && calculatedImageHeight >= 180 && calculatedImageHeight <= 400
-    const hasDescription = linkMetadata?.og?.description
+    const hasDescription =
+      !isDescriptionOnlySymbol(linkMetadata?.og?.description) && linkMetadata?.og?.description?.trim()
     const hasFavicon = ogMetadataProps?.ogShowFavicon && linkMetadata?.faviconLoaded && linkMetadata?.og?.favicon?.url
 
+    if (!hasDescription) {
+      return undefined
+    }
     if (showImage) {
       return 400
     }

--- a/src/components/Message/OGMetadata/index.tsx
+++ b/src/components/Message/OGMetadata/index.tsx
@@ -82,11 +82,7 @@ const OGMetadata = ({
   }, [attachments])
 
   const metadata = useMemo(() => {
-    const metadata = oGMetadata?.[attachment?.url] || null
-    if (metadata?.og?.title && metadata?.og?.description) {
-      return metadata
-    }
-    return null
+    return oGMetadata?.[attachment?.url] || null
   }, [oGMetadata, attachment?.url])
 
   const [imageLoadError, setImageLoadError] = useState(false)
@@ -178,7 +174,20 @@ const OGMetadata = ({
     return url
   }, [attachment])
 
+  const shouldShowTitle = useMemo(() => {
+    return ogShowTitle && metadata?.og?.title && !isDescriptionOnlySymbol(metadata?.og?.description)
+  }, [ogShowTitle, metadata?.og?.title, metadata?.og?.description])
+
+  const shouldShowDescription = useMemo(() => {
+    return ogShowDescription && metadata?.og?.description && !isDescriptionOnlySymbol(metadata?.og?.description)
+  }, [ogShowDescription, metadata?.og?.description])
+
   const showOGMetadata = useMemo(() => {
+    const descriptionIsSymbol = isDescriptionOnlySymbol(metadata?.og?.description)
+    if (descriptionIsSymbol && !shouldShowTitle && !shouldShowDescription) {
+      return false
+    }
+
     return (
       state !== 'deleted' &&
       (metadata?.og?.title ||
@@ -187,7 +196,7 @@ const OGMetadata = ({
         metadata?.og?.favicon?.url) &&
       metadata
     )
-  }, [state, metadata])
+  }, [state, metadata, shouldShowTitle, shouldShowDescription])
 
   const calculatedImageHeight = useMemo(() => {
     if (!metadata?.imageWidth || !metadata?.imageHeight) {
@@ -215,13 +224,13 @@ const OGMetadata = ({
 
   useEffect(() => {
     if (metadataLoaded || oGMetadata?.[attachment?.url]) {
-      if (oGMetadata?.[attachment?.url] && metadataGetSuccessCallback && metadata) {
+      if (showOGMetadata && oGMetadata?.[attachment?.url] && metadataGetSuccessCallback && metadata) {
         metadataGetSuccessCallback(attachment?.url, true, showImage, metadata)
       } else {
         metadataGetSuccessCallback?.(attachment?.url, false, false, metadata)
       }
     }
-  }, [metadataLoaded, oGMetadata, attachment?.url, metadata])
+  }, [metadataLoaded, oGMetadata, attachment?.url, metadata, showOGMetadata, showImage, metadataGetSuccessCallback])
 
   const elements = useMemo(
     () =>
@@ -247,7 +256,7 @@ const OGMetadata = ({
         {
           key: 'title',
           order: resolvedOrder?.title ?? 2,
-          render: ogShowTitle && metadata?.og?.title && !isDescriptionOnlySymbol(metadata?.og?.description) && (
+          render: shouldShowTitle && (
             <Title maxWidth={maxWidth} shouldAnimate={shouldAnimate} padding={infoPadding} color={textPrimary}>
               <span>{metadata?.og?.title?.trim()}</span>
             </Title>
@@ -256,13 +265,11 @@ const OGMetadata = ({
         {
           key: 'description',
           order: resolvedOrder?.description ?? 3,
-          render: ogShowDescription &&
-            metadata?.og?.description &&
-            !isDescriptionOnlySymbol(metadata?.og?.description) && (
-              <Desc maxWidth={maxWidth} shouldAnimate={shouldAnimate} color={textSecondary} padding={infoPadding}>
-                {metadata?.og?.description?.trim()}
-              </Desc>
-            )
+          render: shouldShowDescription && (
+            <Desc maxWidth={maxWidth} shouldAnimate={shouldAnimate} color={textSecondary} padding={infoPadding}>
+              {metadata?.og?.description?.trim()}
+            </Desc>
+          )
         },
         {
           key: 'link',
@@ -285,10 +292,10 @@ const OGMetadata = ({
       maxHeight,
       metadata?.og?.image,
       shouldAnimate,
-      ogShowTitle,
+      shouldShowTitle,
       metadata?.og?.title,
       infoPadding,
-      ogShowDescription,
+      shouldShowDescription,
       metadata?.og?.description,
       textSecondary,
       ogShowUrl,
@@ -337,6 +344,11 @@ const OGMetadata = ({
       dispatch(getChannelByInviteKeyAC(key))
     }
   }, [attachment?.url])
+
+  // If we shouldn't show OG metadata, return null to render as default message
+  if (!showOGMetadata) {
+    return null
+  }
 
   return (
     <OGMetadataContainer

--- a/src/components/Message/OGMetadata/index.tsx
+++ b/src/components/Message/OGMetadata/index.tsx
@@ -20,7 +20,9 @@ const validateUrl = (url: string) => {
   }
 }
 
-const isDescriptionOnlySymbol = (description: string | undefined): boolean => {
+export const isDescriptionOnlySymbol = (description: string | undefined): boolean => {
+  if (!description) return true
+
   const trimmed = description?.trim()
   return !!trimmed && !/[a-zA-Z0-9]/.test(trimmed)
 }
@@ -184,7 +186,7 @@ const OGMetadata = ({
 
   const showOGMetadata = useMemo(() => {
     const descriptionIsSymbol = isDescriptionOnlySymbol(metadata?.og?.description)
-    if (descriptionIsSymbol && !shouldShowTitle && !shouldShowDescription) {
+    if (descriptionIsSymbol) {
       return false
     }
 


### PR DESCRIPTION
Refactor OGMetadata component to improve metadata handling and rendering logic

- Simplified metadata retrieval by removing unnecessary checks for title and description.
- Introduced `shouldShowTitle` and `shouldShowDescription` memoized values to manage visibility conditions.
- Updated `showOGMetadata` logic to incorporate new visibility checks.
- Enhanced rendering conditions for title and description to utilize the new memoized values.
- Added early return for default message rendering when OG metadata should not be displayed.